### PR TITLE
Switch to async client

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,5 +1,5 @@
 fastapi[all]
-meilisearch
+meilisearch-python-async
 python-multipart
 uvicorn
 aiofiles

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -1,24 +1,25 @@
-from fastapi import FastAPI, Request, HTTPException
+from os import path
+
+from fastapi import FastAPI, HTTPException, Request
 from fastapi.responses import FileResponse, HTMLResponse, RedirectResponse
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
-from os import path
-from meilisearch import Client
+from meilisearch_python_async import Client
 
 app = FastAPI()
 
-# MeiliSearch client
-meili_client = Client("http://meilisearch:7700", "abcaee2d0049fd5eb8839117daffc0e293865030216736477ddeec51d7f3ac3e")
-
 @app.get("/{shortcut}")
 async def navigate(shortcut: str):
-    results = meili_client.index("shortcuts").search(shortcut)
+    async with Client(
+        "http://meilisearch:7700",
+        "abcaee2d0049fd5eb8839117daffc0e293865030216736477ddeec51d7f3ac3e"
+    ) as meili_client:
+        results = await meili_client.index("shortcuts").search(shortcut)
 
-    for hit in results["hits"]:
+    for hit in results.hits:
         hit_shortcut = hit.get("shortcut")
         hit_url = hit.get("url")
         if (hit.get("shortcut") == shortcut) and (hit.get("url") is not None):
             return RedirectResponse(hit_url)
 
     raise HTTPException(status_code=404, detail="shortcut not found")
-


### PR DESCRIPTION
This PR switches from the `meilisearch-python` package to `meilisearch-python-async`. Since you are using async with FastAPI this allows you to preform the search without blocking the event loop.